### PR TITLE
Removed extra ":" to match the rest of the messages

### DIFF
--- a/code/src/main.cpp
+++ b/code/src/main.cpp
@@ -521,7 +521,7 @@ void checkIsValidCode()
   else if(isCode1){
     isCode1Unlocked = true;
     EEPROM.writeBool(CODE_1_ADDR, isCode1Unlocked);
-    Serial.print("CODE 1 MATCHES:");
+    Serial.print("CODE 1 MATCHES");
     confirmationFlash();
     resetUserInput();
   }


### PR DESCRIPTION
"CODE 1 MATCHES" includes ":" at the end. None of the other messages have this. I removed the ":" to match the other messages.